### PR TITLE
Feature/capistrano settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 spec/integration/.vagrant/
 spec/integration/log/
+spec/integration/node.json

--- a/lib/capistrano/itamae/variables.rb
+++ b/lib/capistrano/itamae/variables.rb
@@ -12,6 +12,18 @@ module Capistrano
       def itamae_ssh_default_options
         fetch(:itamae_ssh_default_options)
       end
+
+      def itamae_node_options
+        fetch(:itamae_node_options)
+      end
+
+      def itamae_temp_node_file
+        fetch(:itamae_temp_node_file, false)
+      end
+
+      def itamae_node_file
+        Pathname.new(fetch(:itamae_node_file, "node.json"))
+      end
     end
   end
 end

--- a/spec/integration/Rakefile
+++ b/spec/integration/Rakefile
@@ -11,6 +11,7 @@ namespace :spec do
     task :itamae do
       Bundler.with_clean_env do
         sh "bundle exec cap development itamae --trace"
+        sh "bundle exec cap development itamae_with_node_options --trace"
       end
     end
 
@@ -29,6 +30,7 @@ namespace :spec do
     task :itamae do
       Bundler.with_clean_env do
         sh "bundle exec cap --dry-run development itamae --trace"
+        sh "bundle exec cap --dry-run development itamae_with_node_options --trace"
       end
     end
 

--- a/spec/integration/config/deploy.rb
+++ b/spec/integration/config/deploy.rb
@@ -88,3 +88,10 @@ task :itamae do
     itamae_ssh
   end
 end
+
+task :itamae_with_node_options do
+  on roles(:all) do
+    set :itamae_node_options, {:user => "jon.snow"}
+    itamae_ssh "user.rb"
+  end
+end

--- a/spec/integration/cookbooks/user.rb
+++ b/spec/integration/cookbooks/user.rb
@@ -1,0 +1,1 @@
+user node[:user]

--- a/spec/integration/node.json
+++ b/spec/integration/node.json
@@ -1,0 +1,1 @@
+{"user":"jon.snow"}

--- a/spec/integration/spec/user_spec.rb
+++ b/spec/integration/spec/user_spec.rb
@@ -1,0 +1,3 @@
+describe user('jon.snow') do
+  it { should exist }
+end


### PR DESCRIPTION
Allow pass variables from `Capistrano` to `Itamae` recipes.
- It creates `node.json` automatically
- Use a perm file or a temp file

Usage:
`set :itamae_node_options, {:user => "jon.snow", :public_key => 'ssh...'}`