### PR TITLE
Update CI image

### DIFF
--- a/spec/integration/Vagrantfile
+++ b/spec/integration/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
 
     c.vm.box = "centos/7"
     c.vm.provider :digital_ocean do |provider, override|
-      provider.image = "centos-7-0-x64"
+      provider.image = "centos-7-x64"
     end
     c.vm.hostname  = 'itamae-capistrano-centos70'
     c.vm.hostname  += "-#{ENV['WERCKER_RUN_ID']}" if ENV['WERCKER_RUN_ID']


### PR DESCRIPTION
centos-7-0-x64 is removed

https://app.wercker.com/sue445/capistrano-itamae/runs/build/59d4180d14816100010b5aa7?step=59d4183daf52880001edb1aa

```
Bringing machine 'default' up with 'digital_ocean' provider...
==> default: Using existing SSH key: wercker-capistrano-itamae
There was an issue with the request made to the DigitalOcean
API at:

Path: /v2/droplets
URI Params: {:size=>"512MB", :region=>"nyc3", :image=>"centos-7-0-x64", :name=>"itamae-capistrano-centos70-59d4180d14816100010b5aa7", :ssh_keys=>[2355461], :private_networking=>false, :ipv6=>false}

The response status from the API was:

Status: 422
Response: {"id"=>"unprocessable_entity", "message"=>"You specified an invalid image for Droplet creation."}
```