### PR TITLE
Resolved. bundler deprecation warning

### DIFF
--- a/lib/capistrano/itamae/dsl.rb
+++ b/lib/capistrano/itamae/dsl.rb
@@ -18,7 +18,7 @@ module Capistrano
         server = host
 
         run_locally do
-          Bundler.with_clean_env do
+          Bundler.with_original_env do
             with environment do
               execute(*generate_itamae_ssh_command(server, recipe_paths, itamae_options))
             end

--- a/spec/integration/Rakefile
+++ b/spec/integration/Rakefile
@@ -9,7 +9,7 @@ namespace :spec do
   namespace :integration do
     desc "Running itamae to #{HOST} ..."
     task :itamae do
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         sh "bundle exec cap development itamae --trace"
       end
     end
@@ -27,7 +27,7 @@ namespace :spec do
   namespace :dry_run_integration do
     desc "Running itamae with dry run option to #{HOST} ..."
     task :itamae do
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         sh "bundle exec cap --dry-run development itamae --trace"
       end
     end


### PR DESCRIPTION
```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /home/runner/work/capistrano-itamae/capistrano-itamae/lib/capistrano/itamae/dsl.rb:21)
```

c.f. https://github.com/sue445/capistrano-itamae/pull/25/checks?check_run_id=372971093